### PR TITLE
Error status guidelines alignment

### DIFF
--- a/code/API_definitions/one-time-password-sms.yaml
+++ b/code/API_definitions/one-time-password-sms.yaml
@@ -201,8 +201,8 @@ components:
       properties:
         status:
           type: integer
-          minimum: 100
-          maximum: 600
+          minimum: 400
+          maximum: 599
           description: HTTP response status code
         message:
           type: string

--- a/code/API_definitions/one-time-password-sms.yaml
+++ b/code/API_definitions/one-time-password-sms.yaml
@@ -13,7 +13,7 @@ info:
 
     # Resources and Operations overview
     This API currently provides two endpoints, one to send an OTP to a given phone number and another to validate the code received as input.
-  version: 0.1.0
+  version: 0.2.0
   termsOfService: http://example.com/terms/
   contact:
     name: API Support
@@ -200,8 +200,9 @@ components:
         - message
       properties:
         status:
-          type: string
-          pattern: '^[1-5][0-9][0-9]$'
+          type: integer
+          minimum: 100
+          maximum: 600
           description: HTTP response status code
         message:
           type: string
@@ -272,7 +273,7 @@ components:
           examples:
             response:
               value:
-                status: "400"
+                status: 400
                 code: INVALID_ARGUMENT
                 message: Client specified an invalid argument, request body or query param
     ValidateCodeBadRequestError:
@@ -293,7 +294,7 @@ components:
           examples:
             response:
               value:
-                status: "400"
+                status: 400
                 code: ONE_TIME_PASSWORD_SMS.VERIFICATION_FAILED
                 message: The maximum number of attempts for this authentication_id was exceeded without providing a valid OTP
     Unauthenticated:
@@ -321,7 +322,7 @@ components:
           examples:
             response:
               value:
-                status: "401"
+                status: 401
                 code: UNAUTHENTICATED
                 message: Request not authenticated due to missing, invalid, or expired credentials
     PermissionDenied:
@@ -349,7 +350,7 @@ components:
           examples:
             response:
               value:
-                status: "403"
+                status: 403
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action
     SendCodeForbiddenError:
@@ -371,7 +372,7 @@ components:
           examples:
             response:
               value:
-                status: "403"
+                status: 403
                 code: ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED
                 message: Too many OTPs have been requested for this MSISDN. Try later.
     NotFound:
@@ -399,7 +400,7 @@ components:
           examples:
             response:
               value:
-                status: "404"
+                status: 404
                 code: NOT_FOUND
                 message: A specified resource is not found
     MethodNotAllowed:
@@ -427,7 +428,7 @@ components:
           examples:
             response:
               value:
-                status: "405"
+                status: 405
                 code: METHOD_NOT_ALLOWED
                 message: The requested method is not allowed/supported on the target resource
     NotAcceptable:
@@ -455,7 +456,7 @@ components:
           examples:
             response:
               value:
-                status: "406"
+                status: 406
                 code: NOT_ACCEPTABLE
                 message: The server can't produce a response matching the content requested by the client through Accept-* headers
     UnsupportedMediaType:
@@ -483,7 +484,7 @@ components:
           examples:
             response:
               value:
-                status: "415"
+                status: 415
                 code: UNSUPPORTED_MEDIA_TYPE
                 message: The server refuses to accept the request because the payload format is in an unsupported format
     TooManyRequests:
@@ -511,7 +512,7 @@ components:
           examples:
             response:
               value:
-                status: "429"
+                status: 429
                 code: TOO_MANY_REQUESTS
                 message: Either out of resource quota or reaching rate limiting
     Internal:
@@ -539,7 +540,7 @@ components:
           examples:
             response:
               value:
-                status: "500"
+                status: 500
                 code: INTERNAL
                 message: Server error
     Unavailable:
@@ -567,7 +568,7 @@ components:
           examples:
             response:
               value:
-                status: "503"
+                status: 503
                 code: UNAVAILABLE
                 message: Service unavailable
     Timeout:
@@ -595,7 +596,7 @@ components:
           examples:
             response:
               value:
-                status: "504"
+                status: 504
                 code: TIMEOUT
                 message: Request timeout exceeded. Try later.
 externalDocs:

--- a/documentation/MeetingMinutes/2022_Week50_syncCalls.md
+++ b/documentation/MeetingMinutes/2022_Week50_syncCalls.md
@@ -57,7 +57,7 @@ MNOs continue work and aiming to deliver APIs by the end of this week.
 
    -------
 
-   >following items were not presented during meeting, although sharing status and recommendations
+   >discussion continued on Thursday 15th Dec'22
 
 ### NumberVerify SMS 2FA
 
@@ -72,8 +72,10 @@ MNOs continue work and aiming to deliver APIs by the end of this week.
 
 #### Recommendation:
 
-**Keep CAMARA flow consistent with Number Verify / Mobile Connect Verified MSISDN service design.**
-This particular service has to be considered by MNOs as a whole, starting from /authorize, ending with resource call. Otherwise, developers will get lost in various ways of handling device authentication, that is currently covered behind ***/authorize*** endpoint. Telefonica Resource endpoint (either universal like /userinfo, or dedicated, like /numberverify), should handle **ONLY user input matching logic**. TEF proposal creates complexity due to the fact that IP Address+Port passed in resource call is not common way to authenticate device. MNOs handles this in various ways, e.g. by using redirects to dedicated device indentification services, Header Enrichment, private IP based device detection, public IP+port based device detection, so handling this under resource call is not the way. Additionally, by enabling API to be consumed on the resource we create a *query API*, so when fraudster authicates it is easy to violate resource endpoint and send requests for ANY MSISDN. This is why Verified MSISDN authenticates device FIRST and if this is fine, enables user to continue to resource request.
+  >Enable Number Verify API with two flavors:
+  - Based on dedicated endpoint (Orange + TEF proposal)
+  - Keep CAMARA flow consistent with Number Verify / Mobile Connect Verified MSISDN service design.
+In the second case, this particular service has to be considered by MNO community as a whole service flow, starting from /authorize, ending with resource call. Otherwise, software developers might get confused due t ovarious ways of handling device authentication. Number Verify service hides this complexity behind ***/authorize*** endpoint. Device authentication is handled by MNOs in various ways, e.g. by using redirects to dedicated device indentification services, Header Enrichment, private IP based device detection, public IP+port based device detection. Protected resources, either it is a dedicated endpoint (**/number_verify**) or a common (**/userinfo**) should be protected with OAUTH2.0/OpenID Connect **Authorization Code** flow (three-legged-token). This helps to assure that only authorized clients are capable of consuming protected resources.
 
 -----
 
@@ -95,5 +97,5 @@ This particular service has to be considered by MNOs as a whole, starting from /
 
 1. GSMA to provide information about Openverse stakeholders (Done - Helen provided list to Vodafone and Hutchoison).
 2. simSwap - work with 2 yaml files with API description
-3. Number Verify - continue work based on MC Verified MSISDN specification, considering whole service flow.
+3. Number Verify - work with 2 yaml files with API description.
 4. Number Verify SMS 2FA - change the name of API and continue work to deliver OTP validation API.


### PR DESCRIPTION
Related to the [issue#13](https://github.com/camaraproject/OTPvalidationAPI/issues/13)
It includes error status code alignment. I also figured that Meeting minutes that were agreed in Number Verification were not updated here so I also copied that last reviewed version from that repo.
