### PR TITLE
errors and parameters algined with guideline

### DIFF
--- a/code/API_definitions/one-time-password-sms.yaml
+++ b/code/API_definitions/one-time-password-sms.yaml
@@ -13,7 +13,7 @@ info:
 
     # Resources and Operations overview
     This API currently provides two endpoints, one to send an OTP to a given phone number and another to validate the code received as input.
-  version: 0.4.0
+  version: 0.5.0
   termsOfService: http://example.com/terms/
   contact:
     name: API Support
@@ -69,27 +69,27 @@ paths:
               schema:
                 $ref: '#/components/schemas/SendCodeResponse'
         '400':
-          $ref: '#/components/responses/InvalidArgument'
+          $ref: '#/components/responses/Generic400'
         '401':
-          $ref: '#/components/responses/Unauthenticated'
+          $ref: '#/components/responses/Generic401'
         '403':
-          $ref: '#/components/responses/SendCodeForbiddenError'
+          $ref: '#/components/responses/SendCodeForbiddenError403'
         '404':
-          $ref: '#/components/responses/NotFound'
+          $ref: '#/components/responses/Generic404'
         '405':
-          $ref: '#/components/responses/MethodNotAllowed'
+          $ref: '#/components/responses/Generic405'
         '406':
-          $ref: '#/components/responses/NotAcceptable'
+          $ref: '#/components/responses/Generic406'
         '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
+          $ref: '#/components/responses/Generic415'
         '429':
-          $ref: '#/components/responses/TooManyRequests'
+          $ref: '#/components/responses/Generic429'
         '500':
-          $ref: '#/components/responses/Internal'
+          $ref: '#/components/responses/Generic500'
         '503':
-          $ref: '#/components/responses/Unavailable'
+          $ref: '#/components/responses/Generic503'
         '504':
-          $ref: '#/components/responses/Timeout'
+          $ref: '#/components/responses/Generic504'
       security:
         - two_legged:
           - one-time-password-sms:send-validate
@@ -99,7 +99,7 @@ paths:
         - OTP Management
       summary: Verifies the OTP received as input
       description: |-
-        Verifies the code is valid for the received authentication_id
+        Verifies the code is valid for the received authenticationId
       operationId: validateCode
       parameters:
         - in: header
@@ -123,27 +123,27 @@ paths:
               schema:
                 type: string
         '400':
-          $ref: '#/components/responses/ValidateCodeBadRequestError'
+          $ref: '#/components/responses/ValidateCodeBadRequestError400'
         '401':
-          $ref: '#/components/responses/Unauthenticated'
+          $ref: '#/components/responses/Generic401'
         '403':
-          $ref: '#/components/responses/PermissionDenied'
+          $ref: '#/components/responses/Generic403'
         '404':
-          $ref: '#/components/responses/NotFound'
+          $ref: '#/components/responses/Generic404'
         '405':
-          $ref: '#/components/responses/MethodNotAllowed'
+          $ref: '#/components/responses/Generic405'
         '406':
-          $ref: '#/components/responses/NotAcceptable'
+          $ref: '#/components/responses/Generic406'
         '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
+          $ref: '#/components/responses/Generic415'
         '429':
-          $ref: '#/components/responses/TooManyRequests'
+          $ref: '#/components/responses/Generic429'
         '500':
-          $ref: '#/components/responses/Internal'
+          $ref: '#/components/responses/Generic500'
         '503':
-          $ref: '#/components/responses/Unavailable'
+          $ref: '#/components/responses/Generic503'
         '504':
-          $ref: '#/components/responses/Timeout'
+          $ref: '#/components/responses/Generic504'
       security:
         - two_legged:
           - one-time-password-sms:send-validate
@@ -152,29 +152,29 @@ components:
     SendCodeBody:
       type: object
       properties:
-        phone_number:
+        phoneNumber:
           $ref: '#/components/schemas/PhoneNumber'
         message:
           $ref: '#/components/schemas/Message'         
       required:
-        - phone_number
+        - phoneNumber
         - message
     SendCodeResponse:
       type: object
       properties:
-        authentication_id:
+        authenticationId:
           $ref: '#/components/schemas/AuthenticationId'
       required:
-        - authentication_id
+        - authenticationId
     ValidateCodeBody:
       type: object
       properties:
-        authentication_id:
+        authenticationId:
           $ref: '#/components/schemas/AuthenticationId'
         code:
           $ref: '#/components/schemas/Code'
       required:
-        - authentication_id
+        - authenticationId
         - code
     PhoneNumber:
       description: A phone number belonging to the user. 'E164 with an optional +' format
@@ -185,7 +185,7 @@ components:
       type: string
       description: Message template used to compose the content of the SMS sent to the phone number. It must include the following label indicating where to include the short code `{{code}}`
       pattern: .*\{\{code\}\}.*
-      maxLength: 150
+      maxLength: 160
       example: '{{code}} is your short code to authenticate with Cool App via SMS'
     AuthenticationId:
       type: string
@@ -195,52 +195,22 @@ components:
       type: string
       description: temporal, short code to be validated
       example: AJY3
-    ModelError:
+    ErrorInfo:
       type: object
       required:
         - status
+        - code
         - message
       properties:
         status:
           type: integer
-          minimum: 400
-          maximum: 599
           description: HTTP response status code
+        code:
+          type: string
+          description: Code given to this error
         message:
           type: string
-          description: A human readable description of what the event represent
-    SendCodeForbiddenError:
-      allOf:
-        - type: object
-          required:
-            - code
-          properties:
-            code:
-              type: string
-              enum:
-                - PERMISSION_DENIED
-                - ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED
-                - ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_NOT_ALLOWED
-                - ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_BLOCKED
-              default: PERMISSION_DENIED
-              description: Client does not have sufficient permissions to perform this action.
-        - $ref: '#/components/schemas/ModelError'
-    ValidateCodeBadRequestError:
-      allOf:
-        - type: object
-          required:
-            - code
-          properties:
-            code:
-              type: string
-              enum:
-                - INVALID_ARGUMENT
-                - ONE_TIME_PASSWORD_SMS.VERIFICATION_EXPIRED
-                - ONE_TIME_PASSWORD_SMS.VERIFICATION_FAILED
-                - ONE_TIME_PASSWORD_SMS.INVALID_OTP
-              default: INVALID_ARGUMENT
-              description: Client specified an invalid argument, request body or query param.
-        - $ref: '#/components/schemas/ModelError'
+          description: Detailed error description
   securitySchemes:
     two_legged:
       type: oauth2
@@ -250,7 +220,7 @@ components:
           scopes:
             one-time-password-sms:send-validate: Permission to send OTP by SMS and to validate it  
   responses:
-    InvalidArgument:
+    Generic400:
       description: Problem with the client request
       headers:
         x-correlator:
@@ -260,30 +230,17 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - type: object
-                required:
-                  - code
-                properties:
-                  code:
-                    type: string
-                    enum:
-                      - INVALID_ARGUMENT
-                    default: INVALID_ARGUMENT
-                    description: Client specified an invalid argument, request body or query param.
-              - $ref: '#/components/schemas/ModelError'
-          examples:
-            response:
-              value:
-                status: 400
-                code: INVALID_ARGUMENT
-                message: Client specified an invalid argument, request body or query param
-    ValidateCodeBadRequestError:
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 400
+            code: INVALID_ARGUMENT
+            message: Client specified an invalid argument, request body or query param
+    ValidateCodeBadRequestError400:
       description: |-
         Problem with the client request. In addition to regular scenario of `INVALID_ARGUMENT`, another scenarios may exist:
-          - Too many unsuccessful attempts (`{"code": "ONE_TIME_PASSWORD_SMS.VERIFICATION_FAILED","message": "The maximum number of attempts for this authentication_id was exceeded without providing a valid OTP"}`)
-          - Expired authentication_id (`{"code": "ONE_TIME_PASSWORD_SMS.VERIFICATION_EXPIRED","message": "The authentication_id is no longer valid"}`)
-          - OTP is not valid for the provided authentication_id (`{"code": "ONE_TIME_PASSWORD_SMS.INVALID_OTP","message": "The provided OTP is not valid for this authentication_id"}`)
+          - Too many unsuccessful attempts (`{"code": "ONE_TIME_PASSWORD_SMS.VERIFICATION_FAILED","message": "The maximum number of attempts for this authenticationId was exceeded without providing a valid OTP"}`)
+          - Expired authenticationId (`{"code": "ONE_TIME_PASSWORD_SMS.VERIFICATION_EXPIRED","message": "The authenticationId is no longer valid"}`)
+          - OTP is not valid for the provided authenticationId (`{"code": "ONE_TIME_PASSWORD_SMS.INVALID_OTP","message": "The provided OTP is not valid for this authenticationId"}`)
       headers:
         x-correlator:
           description: Correlation id for the different services
@@ -292,14 +249,29 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ValidateCodeBadRequestError'
+            $ref: '#/components/schemas/ErrorInfo'
           examples:
-            response:
+            InvalidArgument:
+              value:
+                status: 400
+                code: INVALID_ARGUMENT
+                message: Client specified an invalid argument, request body or query param
+            VerificationFailed:
               value:
                 status: 400
                 code: ONE_TIME_PASSWORD_SMS.VERIFICATION_FAILED
-                message: The maximum number of attempts for this authentication_id was exceeded without providing a valid OTP
-    Unauthenticated:
+                message: The maximum number of attempts for this authenticationId was exceeded without providing a valid OTP
+            VerificationExpired:
+              value:
+                status: 400
+                code: ONE_TIME_PASSWORD_SMS.VERIFICATION_EXPIRED
+                message: The authenticationId is no longer valid
+            InvalidOtp:
+              value:
+                status: 400
+                code: ONE_TIME_PASSWORD_SMS.INVALID_OTP
+                message: The provided OTP is not valid for this authenticationId
+    Generic401:
       description: Authentication problem with the client request
       headers:
         x-correlator:
@@ -309,25 +281,12 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - type: object
-                required:
-                  - code
-                properties:
-                  code:
-                    type: string
-                    enum:
-                      - UNAUTHENTICATED
-                    default: UNAUTHENTICATED
-                    description: Request not authenticated due to missing, invalid, or expired credentials.
-              - $ref: '#/components/schemas/ModelError'
-          examples:
-            response:
-              value:
-                status: 401
-                code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials
-    PermissionDenied:
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 401
+            code: UNAUTHENTICATED
+            message: Request not authenticated due to missing, invalid, or expired credentials
+    Generic403:
       description: Client does not have sufficient permission
       headers:
         x-correlator:
@@ -337,31 +296,18 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - type: object
-                required:
-                  - code
-                properties:
-                  code:
-                    type: string
-                    enum:
-                      - PERMISSION_DENIED
-                    default: PERMISSION_DENIED
-                    description: Client does not have sufficient permissions to perform this action.
-              - $ref: '#/components/schemas/ModelError'
-          examples:
-            response:
-              value:
-                status: 403
-                code: PERMISSION_DENIED
-                message: Client does not have sufficient permissions to perform this action
-    SendCodeForbiddenError:
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 403
+            code: PERMISSION_DENIED
+            message: Client does not have sufficient permissions to perform this action
+    SendCodeForbiddenError403:
       description: |-
         Client does not have sufficient permissions to perform this action.
         In addition to regular scenario of `PERMISSION_DENIED`, another scenarios may exist:
           - Too many code requests were sent (`{"code": "ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED","message": "Too many OTPs have been requested for this MSISDN. Try later."}`)
-          - The given phone_number can't receive an SMS due to business reasons in the operator, e.g. fraud, receiving SMS is not supported, etc (`{"code": "ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_NOT_ALLOWED","message": "Phone_number can't receive an SMS due to business reasons in the operator."}`)
-          - The given phone_number is blocked to receive SMS due to any blocking business reason in the operator (`{"code": "ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_BLOCKED","message": "Phone_number is blocked to receive SMS due to any blocking business reason in the operator."}`)
+          - The given phoneNumber can't receive an SMS due to business reasons in the operator, e.g. fraud, receiving SMS is not supported, etc (`{"code": "ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_NOT_ALLOWED","message": "Phone_number can't receive an SMS due to business reasons in the operator."}`)
+          - The given phoneNumber is blocked to receive SMS due to any blocking business reason in the operator (`{"code": "ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_BLOCKED","message": "Phone_number is blocked to receive SMS due to any blocking business reason in the operator."}`)
       headers:
         x-correlator:
           description: Correlation id for the different services
@@ -370,14 +316,29 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/SendCodeForbiddenError'
+            $ref: '#/components/schemas/ErrorInfo'
           examples:
-            response:
+            PermissionDenied:
+              value:
+                status: 403
+                code: PERMISSION_DENIED
+                message: Client does not have sufficient permissions to perform this action
+            MaxOtpCodesExceeded:
               value:
                 status: 403
                 code: ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED
                 message: Too many OTPs have been requested for this MSISDN. Try later.
-    NotFound:
+            PhoneNumberNotAllowed:
+              value:
+                status: 403
+                code: ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_NOT_ALLOWED
+                message: Phone_number can't receive an SMS due to business reasons in the operator.
+            Phone_number_blocked:
+              value:
+                status: 403
+                code: ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_BLOCKED
+                message: Phone_number is blocked to receive SMS due to any blocking business reason in the operator.
+    Generic404:
       description: Resource Not Found
       headers:
         x-correlator:
@@ -387,25 +348,12 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - type: object
-                required:
-                  - code
-                properties:
-                  code:
-                    type: string
-                    enum:
-                      - NOT_FOUND
-                    default: NOT_FOUND
-                    description: The specified resource is not found
-              - $ref: '#/components/schemas/ModelError'
-          examples:
-            response:
-              value:
-                status: 404
-                code: NOT_FOUND
-                message: A specified resource is not found
-    MethodNotAllowed:
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 404
+            code: NOT_FOUND
+            message: A specified resource is not found
+    Generic405:
       description: The requested method is not allowed/supported on the target resource
       headers:
         x-correlator:
@@ -415,25 +363,12 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - type: object
-                required:
-                  - code
-                properties:
-                  code:
-                    type: string
-                    enum:
-                      - METHOD_NOT_ALLOWED
-                    default: METHOD_NOT_ALLOWED
-                    description: The requested method is not allowed/supported on the target resource.
-              - $ref: '#/components/schemas/ModelError'
-          examples:
-            response:
-              value:
-                status: 405
-                code: METHOD_NOT_ALLOWED
-                message: The requested method is not allowed/supported on the target resource
-    NotAcceptable:
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 405
+            code: METHOD_NOT_ALLOWED
+            message: The requested method is not allowed/supported on the target resource
+    Generic406:
       description: The server can not produce a response matching the content
       headers:
         x-correlator:
@@ -443,25 +378,12 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - type: object
-                required:
-                  - code
-                properties:
-                  code:
-                    type: string
-                    enum:
-                      - NOT_ACCEPTABLE
-                    default: NOT_ACCEPTABLE
-                    description: The server can't produce a response matching the content requested by the client through Accept-* headers.
-              - $ref: '#/components/schemas/ModelError'
-          examples:
-            response:
-              value:
-                status: 406
-                code: NOT_ACCEPTABLE
-                message: The server can't produce a response matching the content requested by the client through Accept-* headers
-    UnsupportedMediaType:
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 406
+            code: NOT_ACCEPTABLE
+            message: The server can't produce a response matching the content requested by the client through Accept-* headers
+    Generic415:
       description: The server refuses to accept the request because the payload format is in an unsupported format
       headers:
         x-correlator:
@@ -471,25 +393,12 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - type: object
-                required:
-                  - code
-                properties:
-                  code:
-                    type: string
-                    enum:
-                      - UNSUPPORTED_MEDIA_TYPE
-                    default: UNSUPPORTED_MEDIA_TYPE
-                    description: The server refuses to accept the request because the payload format is in an unsupported format.
-              - $ref: '#/components/schemas/ModelError'
-          examples:
-            response:
-              value:
-                status: 415
-                code: UNSUPPORTED_MEDIA_TYPE
-                message: The server refuses to accept the request because the payload format is in an unsupported format
-    TooManyRequests:
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 415
+            code: UNSUPPORTED_MEDIA_TYPE
+            message: The server refuses to accept the request because the payload format is in an unsupported format
+    Generic429:
       description: Either out of resource quota or reaching rate limiting
       headers:
         x-correlator:
@@ -499,25 +408,12 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - type: object
-                required:
-                  - code
-                properties:
-                  code:
-                    type: string
-                    enum:
-                      - TOO_MANY_REQUESTS
-                    default: TOO_MANY_REQUESTS
-                    description: Either out of resource quota or reaching rate limiting.
-              - $ref: '#/components/schemas/ModelError'
-          examples:
-            response:
-              value:
-                status: 429
-                code: TOO_MANY_REQUESTS
-                message: Either out of resource quota or reaching rate limiting
-    Internal:
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 429
+            code: TOO_MANY_REQUESTS
+            message: Either out of resource quota or reaching rate limiting
+    Generic500:
       description: Server error
       headers:
         x-correlator:
@@ -527,25 +423,12 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - type: object
-                required:
-                  - code
-                properties:
-                  code:
-                    type: string
-                    enum:
-                      - INTERNAL
-                    default: INTERNAL
-                    description: Unknown server error.Typically a server bug.
-              - $ref: '#/components/schemas/ModelError'
-          examples:
-            response:
-              value:
-                status: 500
-                code: INTERNAL
-                message: Server error
-    Unavailable:
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 500
+            code: INTERNAL
+            message: Server error
+    Generic503:
       description: Service unavailable. Typically the server is down.
       headers:
         x-correlator:
@@ -555,25 +438,12 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - type: object
-                required:
-                  - code
-                properties:
-                  code:
-                    type: string
-                    enum:
-                      - UNAVAILABLE
-                    default: UNAVAILABLE
-                    description: Request timeout exceeded
-              - $ref: '#/components/schemas/ModelError'
-          examples:
-            response:
-              value:
-                status: 503
-                code: UNAVAILABLE
-                message: Service unavailable
-    Timeout:
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 503
+            code: UNAVAILABLE
+            message: Service unavailable
+    Generic504:
       description: Request time exceeded. If it happens repeatedly, consider reducing the request complexity
       headers:
         x-correlator:
@@ -583,24 +453,11 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - type: object
-                required:
-                  - code
-                properties:
-                  code:
-                    type: string
-                    enum:
-                      - TIMEOUT
-                    default: TIMEOUT
-                    description: Request timeout exceeded
-              - $ref: '#/components/schemas/ModelError'
-          examples:
-            response:
-              value:
-                status: 504
-                code: TIMEOUT
-                message: Request timeout exceeded. Try later.
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 504
+            code: TIMEOUT
+            message: Request timeout exceeded. Try later.
 externalDocs:
   description: Project documentation at CAMARA
   url: https://github.com/camaraproject/NumberVerificationSMS2FA

--- a/documentation/API_documentation/OTP_SMS_API.md
+++ b/documentation/API_documentation/OTP_SMS_API.md
@@ -21,7 +21,7 @@ Before starting to use the API, the developer needs to know about the below spec
 
 Two endpoints are defined in One Time Password SMS API: <br>
 - POST /one-time-password-sms/v0/send-code : Sends an SMS with the desired message and an OTP code to the received phone number
-- POST /one-time-password-sms/v0/validate-code : Verifies the received code as input is valid for the given authentication_id.
+- POST /one-time-password-sms/v0/validate-code : Verifies the received code as input is valid for the given authenticationId.
 
 **Authentication**
 
@@ -48,7 +48,7 @@ Following table defines API endpoints of exposed REST based for One Time Passwor
 | **Endpoint** | **Operation** | **Description** |
 | -------- | --------- | ----------- |
 | POST /one-time-password-sms/v0/send-code | **Request to send an OTP code** | Create request in order to send an OTP code with the given message to a mobile phone number |
-| POST /one-time-password-sms/v0/validate-code | **Request to validate an OTP code** | Create a request to validate an OTP code for the given authentication_id |
+| POST /one-time-password-sms/v0/validate-code | **Request to validate an OTP code** | Create a request to validate an OTP code for the given authenticationId |
 
 
 #### One Time Password SMS API Resource Operations:
@@ -56,16 +56,16 @@ Following table defines API endpoints of exposed REST based for One Time Passwor
 
 | **Request code** |
 | -------------------------- |
-| **HTTP Request**<br> POST /one-time-password-sms/v0/send-code<br>**Query Parameters**<br> No query parameters are defined.<br>**Path Parameters**<br> No path parameters are defined.<br>**Request Body Parameters**<br> **phone_number**: A phone number belonging to the user. 'E164 with +' format.<br> **message**: Message template used to compose the content of the SMS sent to the phone number. It must include the following label indicating where to include the short code `{{code}}`.
+| **HTTP Request**<br> POST /one-time-password-sms/v0/send-code<br>**Query Parameters**<br> No query parameters are defined.<br>**Path Parameters**<br> No path parameters are defined.<br>**Request Body Parameters**<br> **phoneNumber**: A phone number belonging to the user. 'E164 with +' format.<br> **message**: Message template used to compose the content of the SMS sent to the phone number. It must include the following label indicating where to include the short code `{{code}}`.
 
- <br>**Response**<br> **200: OK**<br>  Response body: <br>**authentication_id** : Unique id of the verification attempt the code belongs to.<br> **400:** **INVALID_ARGUMENT**<br> **401:** **UNAUTHENTICATED** <br> **403:** **PERMISSION_DENIED** <br> **403:** **ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED** <br> **403:** **ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_NOT_ALLOWED** <br> **403:** **ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_BLOCKED** <br> **404:** **NOT_FOUND**<br> **405:** **METHOD_NOT_ALLOWED**<br> **406:** **NOT_ACCEPTABLE**<br> **415:** **UNSUPPORTED_MEDIA_TYPE**<br> **429:** **TOO_MANY_REQUESTS**<br> **500:** **INTERNAL**<br> **503:** **UNAVAILABLE**<br> **504:** **TIMEOUT**<br>
+ <br>**Response**<br> **200: OK**<br>  Response body: <br>**authenticationId** : Unique id of the verification attempt the code belongs to.<br> **400:** **INVALID_ARGUMENT**<br> **401:** **UNAUTHENTICATED** <br> **403:** **PERMISSION_DENIED** <br> **403:** **ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED** <br> **403:** **ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_NOT_ALLOWED** <br> **403:** **ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_BLOCKED** <br> **404:** **NOT_FOUND**<br> **405:** **METHOD_NOT_ALLOWED**<br> **406:** **NOT_ACCEPTABLE**<br> **415:** **UNSUPPORTED_MEDIA_TYPE**<br> **429:** **TOO_MANY_REQUESTS**<br> **500:** **INTERNAL**<br> **503:** **UNAVAILABLE**<br> **504:** **TIMEOUT**<br>
 <br>
 
 <br>
 
 | **Validate code** |
 | -------------------------- |
-| **HTTP Request**<br> POST /one-time-password-sms/v0/validate-code<br>**Query Parameters**<br> No query parameters are defined.<br>**Path Parameters**<br> No path parameters are defined.<br>**Request Body Parameters**<br> **authentication_id**: Unique id of the verification attempt the code belongs to.<br> **code**: Temporal, short code to be validated.
+| **HTTP Request**<br> POST /one-time-password-sms/v0/validate-code<br>**Query Parameters**<br> No query parameters are defined.<br>**Path Parameters**<br> No path parameters are defined.<br>**Request Body Parameters**<br> **authenticationId**: Unique id of the verification attempt the code belongs to.<br> **code**: Temporal, short code to be validated.
 
  <br>**Response**<br> **204: The OTP was successfully validated**<br> **400:** **INVALID_ARGUMENT**<br> **400:** **ONE_TIME_PASSWORD_SMS.VERIFICATION_EXPIRED** <br> **400:** **ONE_TIME_PASSWORD_SMS.VERIFICATION_FAILED** <br> **400:** **ONE_TIME_PASSWORD_SMS.INVALID_OTP** <br> **401:** **UNAUTHENTICATED** <br> **403:** **PERMISSION_DENIED** <br> **404:** **NOT_FOUND**<br> **405:** **METHOD_NOT_ALLOWED**<br> **406:** **NOT_ACCEPTABLE**<br> **415:** **UNSUPPORTED_MEDIA_TYPE**<br> **429:** **TOO_MANY_REQUESTS**<br> **500:** **INTERNAL**<br> **503:** **UNAVAILABLE**<br> **504:** **TIMEOUT**<br>
 <br>
@@ -82,9 +82,9 @@ Following table provides an overview of common error names, codes, and messages 
 | No | Error Name | Error Code | Error Message |
 | --- | ---------- | ---------- | ------------- |
 |1  |400 |  INVALID_ARGUMENT |  "Client specified an invalid argument, request body or query param" |
-|2  |400 |  ONE_TIME_PASSWORD_SMS.VERIFICATION_EXPIRED |    "The authentication_id is no longer valid" |
-|3  |400 |  ONE_TIME_PASSWORD_SMS.VERIFICATION_FAILED | "The maximum number of attempts for this authentication_id was exceeded without providing a valid OTP" |
-|4  |400 |  ONE_TIME_PASSWORD_SMS.INVALID_OTP |  "The provided OTP is not valid for this authentication_id" |
+|2  |400 |  ONE_TIME_PASSWORD_SMS.VERIFICATION_EXPIRED |    "The authenticationId is no longer valid" |
+|3  |400 |  ONE_TIME_PASSWORD_SMS.VERIFICATION_FAILED | "The maximum number of attempts for this authenticationId was exceeded without providing a valid OTP" |
+|4  |400 |  ONE_TIME_PASSWORD_SMS.INVALID_OTP |  "The provided OTP is not valid for this authenticationId" |
 |5  |401 |  UNAUTHENTICATED |  "Request not authenticated due to missing, invalid, or expired credentials" |
 |6  |403 |  PERMISSION_DENIED |  "Client does not have sufficient permissions to perform this action" |
 |7  |403 |  ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED |  "Too many OTPs have been requested for this MSISDN. Try later." |
@@ -115,13 +115,13 @@ Please note, the credentials for API authentication purposes need to be adjusted
 
 | Snippet 1. Request code  |
 | ----------------------------------------------- |
-| curl -X 'POST' `https://sample-base-url/one-time-password-sms/v0/validate-code`   <br>    -H 'accept: application/json' <br>    -H 'Content-Type: application/json'<br>    -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbG...."<br>    -d '{ "phone_number": "+346661113334", <br> "message": "{{code}} is your short code to authenticate with Cool App via SMS"}'  |
-| The response will be: <br> 200 <br>   -d '{ "authentication_id": "ea0840f3-3663-4149-bd10-c7c6b8912105" }'|
+| curl -X 'POST' `https://sample-base-url/one-time-password-sms/v0/validate-code`   <br>    -H 'accept: application/json' <br>    -H 'Content-Type: application/json'<br>    -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbG...."<br>    -d '{ "phoneNumber": "+346661113334", <br> "message": "{{code}} is your short code to authenticate with Cool App via SMS"}'  |
+| The response will be: <br> 200 <br>   -d '{ "authenticationId": "ea0840f3-3663-4149-bd10-c7c6b8912105" }'|
 <br>
 
 | Snippet 2. Validate code  |
 | ----------------------------------------------- |
-| curl -X 'POST' `https://sample-base-url/one-time-password-sms/v0/validate-code`   <br>    -H 'accept: application/json' <br>    -H 'Content-Type: application/json'<br>    -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbG...."<br>    -d '{ "authentication_id": "ea0840f3-3663-4149-bd10-c7c6b8912105", <br> "code": "AJY3"}'  |
+| curl -X 'POST' `https://sample-base-url/one-time-password-sms/v0/validate-code`   <br>    -H 'accept: application/json' <br>    -H 'Content-Type: application/json'<br>    -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbG...."<br>    -d '{ "authenticationId": "ea0840f3-3663-4149-bd10-c7c6b8912105", <br> "code": "AJY3"}'  |
 | The response will be: <br> 204 |
 <br>
 


### PR DESCRIPTION
This PR is to handle [issue#21](https://github.com/camaraproject/OTPvalidationAPI/issues/21) in order to align the API definition with following changes in the guidelines:

- Parameters should be named in lowerCamelCase. [Issue](https://github.com/camaraproject/WorkingGroups/issues/157), [Discussion](https://github.com/camaraproject/WorkingGroups/discussions/169) & [PR](https://github.com/camaraproject/WorkingGroups/pull/171).
- Adjust the schema references in the errors responses and apply the agreed solution: [Issue](https://github.com/camaraproject/WorkingGroups/issues/151) & [PR](https://github.com/camaraproject/WorkingGroups/pull/162).

I removed the restriction for error status as in commonalities there is no agreement about limiting the integer values.

Looking forward to getting your feedback.
