### PR TITLE
Update Codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 
-* @DT-DawidWroblewski @bigludo7
+* @DT-DawidWroblewski @bigludo7 @fernandopradocabrillo


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* subproject management


#### What this PR does / why we need it:
Include Fernando (Telefónica) as codeowner since Dawid step-off and we need more than one operator approving the PRs.

This can be permanent or temporary if DT decides to propose a new codeowner to replace Dawid



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #48
